### PR TITLE
fix: make query concurrent

### DIFF
--- a/vectorstores/pgvector/pgvector.go
+++ b/vectorstores/pgvector/pgvector.go
@@ -219,7 +219,7 @@ func (s Store) createEmbeddingTableIfNotExists(ctx context.Context, tx pgx.Tx) e
 	// See this for more details on HNWS indexes: https://github.com/pgvector/pgvector#hnsw
 	if s.hnswIndex != nil {
 		sql = fmt.Sprintf(
-			`CREATE INDEX IF NOT EXISTS %s_embedding_hnsw ON %s USING hnsw (embedding %s)`,
+			`CREATE INDEX CONCURRENTLY IF NOT EXISTS %s_embedding_hnsw ON %s USING hnsw (embedding %s)`,
 			s.embeddingTableName, s.embeddingTableName, s.hnswIndex.distanceFunction,
 		)
 		if s.hnswIndex.m > 0 && s.hnswIndex.efConstruction > 0 {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Make HNSW index creation concurrent in `Store.createEmbeddingTableIfNotExists` for pgvector
Replace `CREATE INDEX IF NOT EXISTS` with `CREATE INDEX CONCURRENTLY IF NOT EXISTS` in `Store.createEmbeddingTableIfNotExists` within [pgvector.go](https://github.com/signalscode/langchaingo/pull/7/files#diff-26a5cd8bbe502d74f0adca0f180e084785f2dcf3c0d7ccd599074556bf1bdd70), executed via `tx.Exec` when `s.hnswIndex` is set.

#### 📍Where to Start
Start at `Store.createEmbeddingTableIfNotExists` in [pgvector.go](https://github.com/signalscode/langchaingo/pull/7/files#diff-26a5cd8bbe502d74f0adca0f180e084785f2dcf3c0d7ccd599074556bf1bdd70).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c486709. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues

</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->