### PR TITLE
feat(vector): add document hashing

### DIFF
--- a/vectorstores/options.go
+++ b/vectorstores/options.go
@@ -16,8 +16,8 @@ type Options struct {
 	ScoreThreshold     float32
 	Filters            any
 	Embedder           embeddings.Embedder
-	Deduplicater       func(context.Context, schema.Document) bool
-	VectorDeduplicater func(context.Context, []float32) bool // returns true if the vector should be deduplicated
+	Deduplicater       func(context.Context, schema.Document) bool // returns true if the document should be deduplicated
+	VectorDeduplicater func(context.Context, []float32) bool       // returns true if the vector should be deduplicated
 }
 
 // WithNameSpace returns an Option for setting the name space.

--- a/vectorstores/pgvector/pgvector.go
+++ b/vectorstores/pgvector/pgvector.go
@@ -206,6 +206,7 @@ func (s Store) createEmbeddingTableIfNotExists(ctx context.Context, tx pgx.Tx) e
 	document varchar,
 	cmetadata json,
 	"uuid" uuid NOT NULL,
+	document_hash bytea,
 	CONSTRAINT langchain_pg_embedding_collection_id_fkey
 	FOREIGN KEY (collection_id) REFERENCES %s (uuid) ON DELETE CASCADE,
 	PRIMARY KEY (uuid))`, s.embeddingTableName, vectorDimensions, s.collectionTableName)

--- a/vectorstores/pgvector/pgvector.go
+++ b/vectorstores/pgvector/pgvector.go
@@ -217,6 +217,10 @@ func (s Store) createEmbeddingTableIfNotExists(ctx context.Context, tx pgx.Tx) e
 	if _, err := tx.Exec(ctx, sql); err != nil {
 		return err
 	}
+	sql = fmt.Sprintf(`CREATE INDEX IF NOT EXISTS %s_document_hash ON %s (document_hash)`, s.embeddingTableName, s.embeddingTableName)
+	if _, err := tx.Exec(ctx, sql); err != nil {
+		return err
+	}
 
 	// See this for more details on HNWS indexes: https://github.com/pgvector/pgvector#hnsw
 	if s.hnswIndex != nil {

--- a/vectorstores/pgvector/pgvector.go
+++ b/vectorstores/pgvector/pgvector.go
@@ -2,6 +2,7 @@ package pgvector
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -272,8 +273,8 @@ func (s Store) AddDocuments(
 	}
 
 	b := &pgx.Batch{}
-	sql := fmt.Sprintf(`INSERT INTO %s (uuid, document, embedding, cmetadata, collection_id)
-		VALUES($1, $2, $3, $4, $5)`, s.embeddingTableName)
+	sql := fmt.Sprintf(`INSERT INTO %s (uuid, document, embedding, cmetadata, collection_id, document_hash)
+		VALUES($1, $2, $3, $4, $5, $6)`, s.embeddingTableName)
 
 	ids := make([]string, 0, len(docs)-len(skipMap))
 	for docIdx, doc := range docs {
@@ -282,7 +283,8 @@ func (s Store) AddDocuments(
 		}
 		id := uuid.New().String()
 		ids = append(ids, id)
-		b.Queue(sql, id, doc.PageContent, pgvector.NewVector(vectors[docIdx]), doc.Metadata, s.collectionUUID)
+		hash := sha256.Sum256([]byte(doc.PageContent))
+		b.Queue(sql, id, doc.PageContent, pgvector.NewVector(vectors[docIdx]), doc.Metadata, s.collectionUUID, hash[:])
 	}
 	return ids, s.conn.SendBatch(ctx, b).Close()
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add SHA-256 document hashing and persist `document_hash` in pgvector embeddings via `pgvector.Store.createEmbeddingTableIfNotExists` and `pgvector.Store.addDocuments` to support document hashing
Add a `bytea` `document_hash` column to the pgvector embeddings table and compute/store a SHA-256 of `doc.PageContent` on insert; add inline comments clarifying deduplication boolean semantics in `vectorstores.Options`. See [pgvector.go](https://github.com/signalscode/langchaingo/pull/14/files#diff-26a5cd8bbe502d74f0adca0f180e084785f2dcf3c0d7ccd599074556bf1bdd70) and [options.go](https://github.com/signalscode/langchaingo/pull/14/files#diff-c34bcfc50dace047297e972c4245ad856e1ad240d79a7a39c55d61f07d0ed9e6).

#### 📍Where to Start
Start with `pgvector.Store.addDocuments` in [pgvector.go](https://github.com/signalscode/langchaingo/pull/14/files#diff-26a5cd8bbe502d74f0adca0f180e084785f2dcf3c0d7ccd599074556bf1bdd70), then review `pgvector.Store.createEmbeddingTableIfNotExists` for the schema change.

<!-- Macroscope's changelog starts here -->
#### Changes since #14 opened

- Added b-tree index creation for document_hash column in pgvector embeddings table initialization [ac33d3f]
<!-- Macroscope's changelog ends here -->

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 758ba5a. 2 files reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>vectorstores/pgvector/pgvector.go — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 288](https://github.com/signalscode/langchaingo/blob/758ba5a4a0ec754432a3472a3e253673c5348170/vectorstores/pgvector/pgvector.go#L288): Missing database migration for `document_hash` column causes `AddDocuments` to fail on existing tables. The `createEmbeddingTableIfNotExists` uses `CREATE TABLE IF NOT EXISTS` which won't add the new `document_hash` column to tables that already exist. When `AddDocuments` is called, the INSERT statement at line 277-278 includes `document_hash`, but the column won't exist in pre-existing tables. This causes a PostgreSQL error like "column document_hash does not exist" and prevents any document insertion for users upgrading from a previous version. An `ALTER TABLE ... ADD COLUMN IF NOT EXISTS document_hash bytea` migration is needed. <b>[ Out of scope ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->