### PR TITLE
Feat(db): document hash

### DIFF
--- a/vectorstores/options.go
+++ b/vectorstores/options.go
@@ -16,8 +16,8 @@ type Options struct {
 	ScoreThreshold     float32
 	Filters            any
 	Embedder           embeddings.Embedder
-	Deduplicater       func(context.Context, schema.Document) bool
-	VectorDeduplicater func(context.Context, []float32) bool // returns true if the vector should be deduplicated
+	Deduplicater       func(context.Context, schema.Document) bool // returns true if the document should be deduplicated
+	VectorDeduplicater func(context.Context, []float32) bool       // returns true if the vector should be deduplicated
 }
 
 // WithNameSpace returns an Option for setting the name space.

--- a/vectorstores/pgvector/pgvector.go
+++ b/vectorstores/pgvector/pgvector.go
@@ -206,6 +206,7 @@ func (s Store) createEmbeddingTableIfNotExists(ctx context.Context, tx pgx.Tx) e
 	document varchar,
 	cmetadata json,
 	"uuid" uuid NOT NULL,
+	document_hash bytea,
 	CONSTRAINT langchain_pg_embedding_collection_id_fkey
 	FOREIGN KEY (collection_id) REFERENCES %s (uuid) ON DELETE CASCADE,
 	PRIMARY KEY (uuid))`, s.embeddingTableName, vectorDimensions, s.collectionTableName)

--- a/vectorstores/pgvector/pgvector.go
+++ b/vectorstores/pgvector/pgvector.go
@@ -217,6 +217,10 @@ func (s Store) createEmbeddingTableIfNotExists(ctx context.Context, tx pgx.Tx) e
 	if _, err := tx.Exec(ctx, sql); err != nil {
 		return err
 	}
+	sql = fmt.Sprintf(`CREATE INDEX IF NOT EXISTS %s_document_hash ON %s (document_hash)`, s.embeddingTableName, s.embeddingTableName)
+	if _, err := tx.Exec(ctx, sql); err != nil {
+		return err
+	}
 
 	// See this for more details on HNWS indexes: https://github.com/pgvector/pgvector#hnsw
 	if s.hnswIndex != nil {

--- a/vectorstores/pgvector/pgvector.go
+++ b/vectorstores/pgvector/pgvector.go
@@ -2,6 +2,7 @@ package pgvector
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -272,8 +273,8 @@ func (s Store) AddDocuments(
 	}
 
 	b := &pgx.Batch{}
-	sql := fmt.Sprintf(`INSERT INTO %s (uuid, document, embedding, cmetadata, collection_id)
-		VALUES($1, $2, $3, $4, $5)`, s.embeddingTableName)
+	sql := fmt.Sprintf(`INSERT INTO %s (uuid, document, embedding, cmetadata, collection_id, document_hash)
+		VALUES($1, $2, $3, $4, $5, $6)`, s.embeddingTableName)
 
 	ids := make([]string, 0, len(docs)-len(skipMap))
 	for docIdx, doc := range docs {
@@ -282,7 +283,8 @@ func (s Store) AddDocuments(
 		}
 		id := uuid.New().String()
 		ids = append(ids, id)
-		b.Queue(sql, id, doc.PageContent, pgvector.NewVector(vectors[docIdx]), doc.Metadata, s.collectionUUID)
+		hash := sha256.Sum256([]byte(doc.PageContent))
+		b.Queue(sql, id, doc.PageContent, pgvector.NewVector(vectors[docIdx]), doc.Metadata, s.collectionUUID, hash[:])
 	}
 	return ids, s.conn.SendBatch(ctx, b).Close()
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add `document_hash` (SHA-256) persistence and indexing in `pgvector.Store.createEmbeddingTableIfNotExists` and batch insert path in [pgvector.go](https://github.com/signalscode/langchaingo/pull/15/files#diff-26a5cd8bbe502d74f0adca0f180e084785f2dcf3c0d7ccd599074556bf1bdd70)
Add a `bytea` `document_hash` column with a B-tree index and include SHA-256 of `PageContent` in batched inserts in [pgvector.go](https://github.com/signalscode/langchaingo/pull/15/files#diff-26a5cd8bbe502d74f0adca0f180e084785f2dcf3c0d7ccd599074556bf1bdd70). Clarify `Deduplicater` and `VectorDeduplicater` comments in [options.go](https://github.com/signalscode/langchaingo/pull/15/files#diff-c34bcfc50dace047297e972c4245ad856e1ad240d79a7a39c55d61f07d0ed9e6).

#### 📍Where to Start
Start with `pgvector.Store.createEmbeddingTableIfNotExists` in [pgvector.go](https://github.com/signalscode/langchaingo/pull/15/files#diff-26a5cd8bbe502d74f0adca0f180e084785f2dcf3c0d7ccd599074556bf1bdd70), then review the batch insert method that computes and persists `document_hash`.

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ac33d3f. 2 files reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>vectorstores/pgvector/pgvector.go — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 220](https://github.com/signalscode/langchaingo/blob/ac33d3f69baa4ca42a1e4c3b957b219336c93aeb/vectorstores/pgvector/pgvector.go#L220): Schema migration breaks existing deployments. The `CREATE TABLE IF NOT EXISTS` statement (line 203) won't add the new `document_hash bytea` column to existing tables. When initializing a Store against a database with a pre-existing embedding table, the `CREATE INDEX IF NOT EXISTS %s_document_hash ON %s (document_hash)` statement at line 220 will fail with a PostgreSQL error "column document_hash does not exist" because the table was created before this change and lacks the column. Even if the index creation somehow passed, the INSERT at line 281-282 would fail since it references 6 columns including `document_hash` which doesn't exist on legacy tables. There's no `ALTER TABLE ADD COLUMN IF NOT EXISTS document_hash bytea` to handle existing tables. <b>[ Out of scope ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->