### PR TITLE
feat(kb): Add ts vector to lang chain fork

### DIFF
--- a/vectorstores/pgvector/options.go
+++ b/vectorstores/pgvector/options.go
@@ -14,6 +14,7 @@ const (
 	DefaultCollectionStoreTableName = "langchain_pg_collection"
 	DefaultTryCreateExtention       = false
 	DefaultUsePGAdvisoryLocks       = false
+	DefaultGinIndex                 = false
 )
 
 // ErrInvalidOptions is returned when the options given are invalid.
@@ -118,6 +119,13 @@ func WithHNSWIndex(m int, efConstruction int, distanceFunction string) Option {
 	}
 }
 
+// WithGinIndex is an option for specifying if the Gin index should be created.
+func WithGinIndex(ginIndex bool) Option {
+	return func(p *Store) {
+		p.ginIndex = ginIndex
+	}
+}
+
 func applyClientOptions(opts ...Option) (Store, error) {
 	o := &Store{
 		collectionName:      DefaultCollectionName,
@@ -126,6 +134,7 @@ func applyClientOptions(opts ...Option) (Store, error) {
 		collectionTableName: DefaultCollectionStoreTableName,
 		tryCreateExtention:  DefaultTryCreateExtention,
 		usePGAdvisoryLocks:  DefaultUsePGAdvisoryLocks,
+		ginIndex:            DefaultGinIndex,
 	}
 
 	for _, opt := range opts {

--- a/vectorstores/pgvector/pgvector.go
+++ b/vectorstores/pgvector/pgvector.go
@@ -64,6 +64,7 @@ type Store struct {
 	preDeleteCollection bool
 	vectorDimensions    int
 	hnswIndex           *HNSWIndex
+	ginIndex            bool
 	tryCreateExtention  bool
 	usePGAdvisoryLocks  bool
 }
@@ -207,6 +208,7 @@ func (s Store) createEmbeddingTableIfNotExists(ctx context.Context, tx pgx.Tx) e
 	cmetadata json,
 	"uuid" uuid NOT NULL,
 	document_hash bytea,
+	document_tsv tsvector GENERATED ALWAYS AS (to_tsvector('english', COALESCE(document, ''))) STORED,
 	CONSTRAINT langchain_pg_embedding_collection_id_fkey
 	FOREIGN KEY (collection_id) REFERENCES %s (uuid) ON DELETE CASCADE,
 	PRIMARY KEY (uuid))`, s.embeddingTableName, vectorDimensions, s.collectionTableName)
@@ -233,6 +235,12 @@ func (s Store) createEmbeddingTableIfNotExists(ctx context.Context, tx pgx.Tx) e
 		}
 		if _, err := tx.Exec(ctx, sql); err != nil {
 			return err
+		}
+	}
+	if s.ginIndex {
+		sql = fmt.Sprintf(`CREATE INDEX IF NOT EXISTS %s_document_tsv_gin ON %s USING gin (document_tsv)`, s.embeddingTableName, s.embeddingTableName)
+		if _, err := tx.Exec(ctx, sql); err != nil {
+			return fmt.Errorf("failed to create gin index: %w", err)
 		}
 	}
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add `tsvector` column and GIN index support to pgvector store
- Adds a generated stored column `document_tsv` of type `tsvector` to the embedding table DDL in [`pgvector.go`](https://github.com/signalscode/langchaingo/pull/16/files#diff-26a5cd8bbe502d74f0adca0f180e084785f2dcf3c0d7ccd599074556bf1bdd70), computed from the `document` field using `to_tsvector('english', ...)`.
- Adds a `WithGinIndex(bool)` option in [`options.go`](https://github.com/signalscode/langchaingo/pull/16/files#diff-2e8d150f86fa88d56aa7fb70163cc63c415b2c3c3491d30f05713cd8dee77a2b) to optionally create a GIN index on `document_tsv` during table setup; defaults to `false`.
- Behavioral Change: Existing deployments that run `createEmbeddingTableIfNotExists` will have `document_tsv` added to the table schema on next startup.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 016b643.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->