### PR TITLE
feat(db): Add skip create table

### DIFF
--- a/vectorstores/pgvector/options.go
+++ b/vectorstores/pgvector/options.go
@@ -23,6 +23,12 @@ var ErrInvalidOptions = errors.New("invalid options")
 // Option is a function type that can be used to modify the client.
 type Option func(p *Store)
 
+func WithSkipInit(skip bool) Option {
+	return func(p *Store) {
+		p.skipInit = skip
+	}
+}
+
 // WithTryCreateExtention is an option for specifying if the extension should be created if it does not exist.
 func WithTryCreateExtention(tryCreateExtention bool) Option {
 	return func(p *Store) {

--- a/vectorstores/pgvector/pgvector.go
+++ b/vectorstores/pgvector/pgvector.go
@@ -53,6 +53,7 @@ type CloseNoErr interface {
 
 // Store is a wrapper around the pgvector client.
 type Store struct {
+	skipInit            bool
 	embedder            embeddings.Embedder
 	connURL             string
 	conn                PGXConn
@@ -115,14 +116,16 @@ func (s *Store) init(ctx context.Context) error {
 		return err
 	}
 
-	if err := s.createVectorExtensionIfNotExists(ctx, tx); err != nil {
-		return err
-	}
-	if err := s.createCollectionTableIfNotExists(ctx, tx); err != nil {
-		return err
-	}
-	if err := s.createEmbeddingTableIfNotExists(ctx, tx); err != nil {
-		return err
+	if !s.skipInit {
+		if err := s.createVectorExtensionIfNotExists(ctx, tx); err != nil {
+			return err
+		}
+		if err := s.createCollectionTableIfNotExists(ctx, tx); err != nil {
+			return err
+		}
+		if err := s.createEmbeddingTableIfNotExists(ctx, tx); err != nil {
+			return err
+		}
 	}
 	if s.preDeleteCollection {
 		if err := s.RemoveCollection(ctx, tx); err != nil {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add `WithSkipInit` option to skip table creation in pgvector store
Adds a `skipInit` field to the pgvector `Store` struct and a `WithSkipInit(bool)` option to set it. When `skipInit` is true, `Store.init` skips calls to `createVectorExtensionIfNotExists`, `createCollectionTableIfNotExists`, and `createEmbeddingTableIfNotExists`, but still creates or retrieves the collection. This is useful when the database schema is managed externally.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized c3235ac.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->