### PR TITLE
encode thought signature

### DIFF
--- a/llms/googleai/googleai.go
+++ b/llms/googleai/googleai.go
@@ -351,7 +351,7 @@ func convertCandidates(candidates []*genai.Candidate, usage *genai.GenerateConte
 				if part.Thought {
 					thoughtContent := llms.ThoughtContent{
 						Text:      part.Text,
-						Signature: string(part.ThoughtSignature),
+						Signature: base64.StdEncoding.EncodeToString(part.ThoughtSignature),
 					}
 					thoughtParts = append(thoughtParts, thoughtContent)
 					continue


### PR DESCRIPTION
### PR Checklist

- [ ] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [ ] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [ ] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix thought signature encoding to use base64 in `googleai.convertCandidates`
> In [googleai.go](https://github.com/signalscode/langchaingo/pull/18/files#diff-26821f947834dfb79f8a5f46a75ec9ac9ea1e330f11525b1ebb405a4922fa6ee), `ThoughtContent.Signature` was set by casting raw bytes directly to a string, which produces invalid UTF-8 for arbitrary binary data. It now uses `base64.StdEncoding.EncodeToString` to produce a safe string representation. Behavioral Change: any caller reading `ThoughtParts[i].Signature` will now receive a base64-encoded string instead of a raw byte-cast string.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1bb0676.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->